### PR TITLE
Add missing project version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "bank2ynab"
 description = ""
+version = "0.1.0"
 authors = [{ name = "Adrian Nilsson" }]
 requires-python = ">=3.10,<4"
 license = "MIT"


### PR DESCRIPTION
## Description

Both `name` and `version` are mandatory. 
`version` was removed by a bad merge (b2d3af8566ff7b2f23cdd2b509eea2370ed6d72e) and needs to be reintroduced.